### PR TITLE
Updated guidelines

### DIFF
--- a/docs/guidelines.md
+++ b/docs/guidelines.md
@@ -6,13 +6,13 @@
 
 * GPL Compliant Codebase
 
-* Php 7.2 minimum version compatibility
+* Php 7.4 minimum version compatibility
 
 * Detailed docblocks need to be present throughout your codebase
 
 * Plugins must validate against an established ruleset for PHP and meet ES6 standards for JavaScript, passing linting tests against these rules.
 
-    * The preferred PHPCS ruleset is a custom one made up of PSR12 and some necessary checks for WordPress security, sanitization, and prevention of deprecated code. 
+    * The preferred PHPCS ruleset is a [custom one](/docs/osdxpruleset.xml) made up of PSR12 and some necessary checks for WordPress security, sanitization, and prevention of deprecated code. 
 
     * Javascript should validate against ES6, at a minimum.
 

--- a/docs/guidelines.md
+++ b/docs/guidelines.md
@@ -10,13 +10,13 @@
 
 * Detailed docblocks need to be present throughout your codebase
 
-* Plugins must validate against an established ruleset for PHP and Javascript, passing linting tests against these rules.
+* Plugins must validate against an established ruleset for PHP and meet ES6 standards for JavaScript, passing linting tests against these rules.
 
-    * PSR12 is the desired PHPCS ruleset to validate against, though if you're already using the WordPress Coding Standards, you may continue to do so for each osDXP plugin release for the immediate future.
+    * The preferred PHPCS ruleset is a custom one made up of PSR12 and some necessary checks for WordPress security, sanitization, and prevention of deprecated code. 
 
     * Javascript should validate against ES6, at a minimum.
 
-* No SaaS-ification of Client Data(No Customer Data is saved on Vendors System)
+* No SaaS-ification of Client Data (No Customer Data is saved on Vendors System)
 
 * Clear data privacy standards
 

--- a/docs/osdxpruleset.xml
+++ b/docs/osdxpruleset.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0"?>
+<ruleset name="CF PSR12-based Coding Standards">
+	<description>Crowd Favorite custom variant of PSR12 with WordPress security checks for PHP development</description>
+
+	<!-- Default ruleset is PSR12 with one exception - tabs instead of spaces for accessibilty -->
+	<rule ref="PSR12">
+		<exclude name="Generic.WhiteSpace.DisallowTabIndent"/>
+	</rule>
+	<rule ref="Generic.WhiteSpace.DisallowSpaceIndent"/>
+
+	<!-- WordPress rules -->
+	<rule ref="WordPress.DB.PreparedSQL"/>
+  <rule ref="WordPress.DB.PreparedSQLPlaceholders"/>
+	<rule ref="WordPress.DB.RestrictedClasses"/>
+	<rule ref="WordPress.DB.RestrictedFunctions"/>
+	<rule ref="WordPress.Security.EscapeOutput"/>
+	<rule ref="WordPress.Security.NonceVerification"/>
+	<rule ref="WordPress.WP.EnqueuedResources"/>
+  <rule ref="WordPress.WP.EnqueuedResourceParameters"/>
+	<rule ref="WordPress.WP.DeprecatedClasses"/>
+	<rule ref="WordPress.WP.DeprecatedFunctions"/>
+  <rule ref="WordPress.WP.DeprecatedParameters"/>
+	<rule ref="WordPress.WP.DeprecatedParameterValues"/>
+	<rule ref="WordPress.WP.AlternativeFunctions"/>
+	<rule ref="WordPress.WP.DiscouragedConstants"/>
+	<rule ref="WordPress.WP.DiscouragedFunctions"/>
+
+
+	<!-- Exclude node and vendor directories -->
+	<exclude-pattern>*/node_modules/*</exclude-pattern>
+	<exclude-pattern>*/vendor/*</exclude-pattern>
+
+	<!-- Check the files in the project directory. Where this xml file should be located. -->
+	<file>.</file>
+
+	<!-- Exclude the project directory path from the report, making for cleaner output. -->
+	<arg name="basepath" value="."/>
+
+	<!-- Check only PHP files. -->
+	<arg name="extensions" value="php"/>
+
+	<!-- Display output in color on the command line. Show the sniffs. Show progress. -->
+	<arg name="colors" />
+	<arg value="s" />
+	<arg value="p" />
+
+</ruleset>


### PR DESCRIPTION
Added an example phpcs ruleset xml file and linked it from the guidelines page. 

In the ruleset file, I updated and reformatted some of the WordPress rules, following some of what Inpsyde has done with their custom [WordPress ruleset](https://github.com/inpsyde/php-coding-standards/blob/master/phpcs.xml). They've gone beyond simply saying "just start with PSR12" and instead have leaned heavy into raising the bar by bringing in VIP rules and more. It would be interesting to compare both rulesets against the same PHP code and see the differences in what's caught by phpcs. 